### PR TITLE
Issue 1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "objectLiteralShorthandProperties": true,
     "destructuring": true,
     "arrowFunctions": true,
-    "jsx": true
+    "jsx": true,
+    "templateStrings": true
   },
   "env": {
     "node": true,

--- a/src/ui/actions/Actions.js
+++ b/src/ui/actions/Actions.js
@@ -1,7 +1,6 @@
 
 var Dispatcher = require('../dispatcher/Dispatcher');
 var {Actions, ToggleCheckedAsOrder} = require('../const');
-var _ = require('underscore');
 
 
 

--- a/src/ui/actions/Actions.js
+++ b/src/ui/actions/Actions.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 
 
 
-module.exports = { checkAs, sort, toggleCheckedAs };
+module.exports = { checkAs, toggleCheckedAs };
 
 
 
@@ -18,11 +18,6 @@ function checkAs(revision, capture, as) {
     type: Actions.CHECKAS,
     revision, capture, as
   });
-}
-
-function sort(names) {
-  if (!_.isArray(names)) names = [names];
-  console.log(names);
 }
 
 function toggleCheckedAs(capture, direction) {

--- a/src/ui/app/revision.js
+++ b/src/ui/app/revision.js
@@ -91,4 +91,3 @@ var Revision = React.createClass({
   }
 });
 module.exports = Revision;
-

--- a/src/ui/components/Table.js
+++ b/src/ui/components/Table.js
@@ -19,7 +19,10 @@ var Table = React.createClass({
           <thead>
             <tr>
               {_.map(this.props.columns, column =>
-                <th onClick={column.onClick} className={getCellCssName(column, true)} key={column.id}>{column.label}</th>)}
+                <th className={getCellCssName(column, true)} key={column.id}>
+                  <a className="cell__link" href={this.props.pageUrlBuilder(1, [column.id, column.sort])}>{column.label}</a>
+                </th>
+              )}
             </tr>
           </thead>
         </table>
@@ -81,9 +84,9 @@ var Table = React.createClass({
 
 function getCellCssName(column, isHeader) {
   return 'cell ' +
-         'cell--' + column.id +
-         (isHeader && column.onClick ? ' cell--clickable' : '') +
-         (column.cssModifier ? ' cell--' + column.cssModifier : '');
+         `cell--${column.id}` +
+         (isHeader && column.sort ? ` cell--ordered cell--ordered-${column.sort.toLowerCase()}` : '') +
+         (column.cssModifier ? ` cell--${column.cssModifier}` : '');
 }
 
 module.exports = Table;

--- a/src/ui/sass/main.sass
+++ b/src/ui/sass/main.sass
@@ -24,6 +24,8 @@ $btn-default-color: $gray-dark
 $btn-default-bg: #e0e3e5
 $btn-default-border: darken(#e0e3e5, 5%)
 
+$fa-font: normal normal normal 14px/1 FontAwesome
+
 
 
 @import _bootstrap
@@ -104,11 +106,17 @@ $btn-default-border: darken(#e0e3e5, 5%)
     width: 100%
     .progress
       margin-bottom: 0
-  .cell--clickable
+  .cell__link
     text-decoration: underline
     cursor: pointer
     &:hover
       text-decoration: none
+  .cell--ordered::after
+    font: $fa-font
+  .cell--ordered-asc::after
+    content: $fa-var-sort-asc
+  .cell--ordered-desc::after
+    content: $fa-var-sort-desc
 
 .paged-table--captures
   .cell--captureName


### PR DESCRIPTION
Add column sort function to the revisions table
- ソートできるようにした
- リビジョンテーブルのカラムをクリックしたら hash を変えるようにした
  - ページをリロードしても前に表示していたソート状態で表示される
- templateStrings を使うために eslintrc を変更した（使わないほうがよかったら戻します）
